### PR TITLE
Replace isIgnored with isGotham

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ Note: some of these workflows are internal to Palantir. It is not expected that 
 3. Remember to add a changeset (following the instructions above)
 4. Commit and open a PR
 
+### Adding a new Gotham SDK
+If you are generating a new Gotham SDK for the first time, you must add it to the namespace mapping in `isGothamNamespace.ts`:
+```js
+  const gothamNamespaces = new Set([
+    "TargetWorkbench",
+    "Gaia",
+    "MapRendering",
+    "Geojson",
+    "GothamCore",
+    {yourGothamNamespace}
+  ]); /* gotham-only */
+```
+
 ### Publishing a release
 
 1. Follow the dev workflow above

--- a/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
+++ b/packages/platform-sdk-generator/src/generatePlatformSdkv2.ts
@@ -21,7 +21,7 @@ import { addPackagesToPackageJson } from "./addPackagesToPackageJson.js";
 import { copyright } from "./copyright.js";
 import { generateImports, SKIP } from "./generateImports.js";
 import { writeResource2 } from "./generateResource2.js";
-import { isIgnoredType } from "./isIgnoredType.js";
+import { isGothamType } from "./isGothamType.js";
 import type { Component } from "./model/Component.js";
 import { Model } from "./model/Model.js";
 import type { Namespace } from "./model/Namespace.js";
@@ -177,7 +177,7 @@ export async function generateComponents(
       `;
 
   for (const component of ns.components) {
-    if (isIgnoredType(component.component, packagePrefix)) {
+    if (isGotham === !isGothamType(component.component)) {
       continue;
     }
     out += component.getDeclaration(ns.name);
@@ -213,7 +213,7 @@ export async function generateErrors(
       `;
 
   for (const error of ns.errors) {
-    if (isIgnoredType(error.spec, packagePrefix)) {
+    if (isGotham === !isGothamType(error.spec)) {
       continue;
     }
     out += error.getDeclaration(ns.name);

--- a/packages/platform-sdk-generator/src/isGothamNamespace.ts
+++ b/packages/platform-sdk-generator/src/isGothamNamespace.ts
@@ -14,29 +14,18 @@
  * limitations under the License.
  */
 
-const gothamNamespaces = new Set([
-  "TargetWorkbench",
-  "Gaia",
-  "MapRendering",
-  "Geojson",
-]); /* gotham-only */
-const neverIgnore = new Set(["Core"]);
-const alwaysIgnore = new Set(["Operations"]);
-
-export function isIgnoredNamespace(
+export function isGothamNamespace(
   ns?: string,
-  packagePrefix?: string,
 ): boolean {
-  if (!ns || !packagePrefix) return true;
+  if (!ns) return true;
 
-  if (alwaysIgnore.has(ns)) {
-    return true;
-  }
-  if (neverIgnore.has(ns)) {
-    return false;
-  }
+  const gothamNamespaces = new Set([
+    "TargetWorkbench",
+    "Gaia",
+    "MapRendering",
+    "Geojson",
+    "GothamCore",
+  ]); /* gotham-only */
 
-  const isGotham = packagePrefix === "gotham";
-
-  return (isGotham === !gothamNamespaces.has(ns));
+  return gothamNamespaces.has(ns);
 }

--- a/packages/platform-sdk-generator/src/isGothamType.ts
+++ b/packages/platform-sdk-generator/src/isGothamType.ts
@@ -15,12 +15,11 @@
  */
 
 import type * as ir from "@osdk/docs-spec-platform";
-import { isIgnoredNamespace } from "./isIgnoredNamespace.js";
+import { isGothamNamespace } from "./isGothamNamespace.js";
 import type { ErrorType } from "./model/ErrorType.js";
 
-export function isIgnoredType(
+export function isGothamType(
   component: ir.Component | ir.Error,
-  packagePrefix: string,
 ): boolean {
-  return isIgnoredNamespace(component.locator.namespaceName, packagePrefix);
+  return isGothamNamespace(component.locator.namespaceName);
 }

--- a/packages/platform-sdk-generator/src/model/Model.ts
+++ b/packages/platform-sdk-generator/src/model/Model.ts
@@ -17,8 +17,8 @@
 import type * as ir from "@osdk/docs-spec-platform";
 import * as path from "node:path";
 import { ensurePackageSetup } from "../generatePlatformSdkv2.js";
-import { isIgnoredNamespace } from "../isIgnoredNamespace.js";
-import { isIgnoredType } from "../isIgnoredType.js";
+import { isGothamNamespace } from "../isGothamNamespace.js";
+import { isGothamType } from "../isGothamType.js";
 import { mapObjectValues } from "../util/mapObjectValues.js";
 import { BinaryType } from "./BinaryType.js";
 import { BuiltinType } from "./BuiltinType.js";
@@ -125,10 +125,10 @@ export class Model {
   }): Promise<Model> {
     const model = new Model(opts);
 
-    const prefix = opts["packagePrefix"] ?? "foundry";
+    const isGotham = (opts["packagePrefix"] ?? "foundry") === "gotham";
 
     for (const ns of ir.namespaces) {
-      if (isIgnoredNamespace(ns.name, prefix)) continue;
+      if (isGotham === !isGothamNamespace(ns.name)) continue;
       if (
         ns.version !== opts.endpointVersion
       ) continue;
@@ -136,12 +136,12 @@ export class Model {
       await model.#addNamespace(ns.name, ns);
 
       for (const c of ns.components) {
-        if (isIgnoredType(c, prefix)) continue;
+        if (isGotham === !isGothamType(c)) continue;
         model.#addComponent(c);
       }
 
       for (const e of ns.errors) {
-        if (isIgnoredType(e, prefix)) continue;
+        if (isGotham === !isGothamType(e)) continue;
         model.#addError(e);
       }
 
@@ -159,7 +159,7 @@ export class Model {
       );
 
       for (const c of deprecatedOntologiesComponents?.components ?? []) {
-        if (isIgnoredType(c, prefix)) continue;
+        if (isGotham === !isGothamType(c)) continue;
         c.locator.namespaceName = "Core";
         model.#addComponent(c, true);
       }
@@ -169,7 +169,7 @@ export class Model {
       );
 
       for (const c of deprecatedOntologiesErrors?.errors ?? []) {
-        if (isIgnoredType(c, prefix)) continue;
+        if (isGotham === !isGothamType(c)) continue;
         c.locator.namespaceName = "Core";
         model.#addError(c, true);
       }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Namespace filtering occurs in `isIgnoredNamespace` and `isIgnoredType`, which takes in an unnecessary `prefix` argument

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Namespace filtering occurs in `isGothamNamespace`, which uses a mutually exclusive Gotham namespace mapping.
==COMMIT_MSG==

## Docs
Updated the README documentation:
- Dev Workflow: instructions for adding new Gotham APIs to the namespace mapping

## Potential Downsides
This is dependent on Gotham APIs in api-gateway only depending on other Gotham namespaces, like `GothamCore` or `Geojson`. These dependencies are defined in `api-gateway-api-v2/build.gradle`